### PR TITLE
Fix: Toast pop-up (non-ucsc gmail rejection) not showing

### DIFF
--- a/RoomMatchU/src/contexts/AuthContext.tsx
+++ b/RoomMatchU/src/contexts/AuthContext.tsx
@@ -138,7 +138,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         console.warn(`Blocked non-UCSC email sign-in: ${email}`);
         toast.error('Only UCSC email addresses are allowed.');
         await signOut(auth);
-        window.location.reload();
+        setTimeout(async () => {
+          window.location.reload();
+        }, 3000); // 3 second delay to allow pop-up error to show
         return;
       }
 


### PR DESCRIPTION
Delay window refresh to allow toast pop to display when non-ucsc gmail try to sign in.